### PR TITLE
✨ feat: add captcha to contact form

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -27,6 +27,10 @@ export default defineConfig({
 
   vite: {
     plugins: [tailwindcss()],
+    server: {
+      // Only use this for local development
+      // allowedHosts: ["test.frustrationmagazine.com"],
+    },
   },
 
   integrations: [react(), sitemap()],

--- a/apps/web/src/pages/contact/index.astro
+++ b/apps/web/src/pages/contact/index.astro
@@ -8,6 +8,11 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+const INVALID_CAPTCHA_STATUS = {
+  type: "invalid-captcha",
+  message: "Veuillez valider le captcha",
+};
+
 const ERROR_STATUS = {
   type: "error",
   message: "Une erreur inattendue est survenue",
@@ -18,11 +23,17 @@ const SUCCESS_STATUS = {
   message:
     "🙂 Votre message a bien été envoyé ! Nous tâcherons de vous répondre dans les plus brefs délais",
 };
+
 let status = null;
 
 if (Astro.request.method === "POST") {
   if (!process.env.RESEND_API_KEY) {
     console.warn("🔎 Missing api key to add subscriber");
+    status = ERROR_STATUS;
+  }
+
+  if (!process.env.HCAPTCHA_SITE_KEY) {
+    console.warn("🔎 Missing hcaptcha site key");
     status = ERROR_STATUS;
   }
 
@@ -47,18 +58,24 @@ if (Astro.request.method === "POST") {
     const email = data.get("email");
     const message = data.get("message");
 
-    await resend.emails.send({
-      from: "redaction@frustrationmagazine.fr",
-      to: ["redaction@frustrationmagazine.fr"],
-      subject: `Formulaire de contact - ${email}`,
-      html: `
-      <h3>Demande envoyée par : ${email} le ${formattedDate}</h3>
-      <h5>Message :</h5>
-      <p>${message}</p>
-      `,
-    });
+    const hcaptchaResponse = data.get("h-captcha-response");
 
-    status = SUCCESS_STATUS;
+    if (!hcaptchaResponse) {
+      status = INVALID_CAPTCHA_STATUS;
+    } else {
+      await resend.emails.send({
+        from: "redaction@frustrationmagazine.fr",
+        to: ["redaction@frustrationmagazine.fr"],
+        subject: `Formulaire de contact - ${email}`,
+        html: `
+        <h3>Demande envoyée par : ${email} le ${formattedDate}</h3>
+        <h5>Message :</h5>
+        <p>${message}</p>
+        `,
+      });
+
+      status = SUCCESS_STATUS;
+    }
   } catch (error) {
     if (error instanceof Error) console.error(error.message);
     status = ERROR_STATUS;
@@ -121,7 +138,7 @@ export const prerender = false;
       />
       {
         status &&
-          (status.type === "error" ? (
+          (status.type === ERROR_STATUS.type ? (
             <p class="bg-red-200 text-red-700 p-4">
               😔 Une erreur est survenue. Veuillez réessayer ou nous contacter
               directement à l'adresse{" "}
@@ -132,10 +149,13 @@ export const prerender = false;
               </a>{" "}
               si le problème persiste.
             </p>
-          ) : status.type === "success" ? (
+          ) : status.type === INVALID_CAPTCHA_STATUS.type ? (
+            <p class="bg-red-200 text-red-700 p-4">{status.message}</p>
+          ) : status.type === SUCCESS_STATUS.type ? (
             <p class="bg-green-200 text-green-700 p-4">{status.message}</p>
           ) : null)
       }
+      <div class="h-captcha mx-auto" data-sitekey={process.env.HCAPTCHA_SITE_KEY}></div>
       <Button
         type="submit"
         className="text-xl font-bakbak w-fit px-8 bg-black hover:bg-black hover:text-frustration-yellow text-frustration-yellow py-6 mx-auto"
@@ -144,4 +164,5 @@ export const prerender = false;
     </form>
   </article>
 </PageLayout>
-<script></script>
+
+<script src="https://js.hcaptcha.com/1/api.js" async defer is:inline></script>


### PR DESCRIPTION
- ajout du captcha dans le form, avec la logique de validation et le message d'erreur approprié
- ajout d’une variable d’env dans infisical : `HCAPTCHA_SITE_KEY`
- config optionnelle pour autoriser un sous-domaine "test" → le captcha ne peut pas être testé sur une adresse locale → modifier l'host de la machine pour rediriger `test.frustrationmagazine.fr` vers localhost, autoriser cet host dans la configuration vite, et y accéder depuis `test.frustrationmagazine.fr:4321`